### PR TITLE
Only process Altherma models

### DIFF
--- a/custom_components/daikin_residential_altherma/daikin_api.py
+++ b/custom_components/daikin_residential_altherma/daikin_api.py
@@ -495,13 +495,17 @@ class DaikinApi:
             #DAMIANO
             #_LOGGER.warning("DAMIANO daikin_api.py - deviceobj '%s'", str(dev_data))
             #DAMIANO
-            device_model = device.get_value("gateway", "modelInfo")
-            #_LOGGER.warning("DAMIANO daikin_api.py - Device '%s'", device_model)
-            if device_model is None:
-                _LOGGER.warning("Device '%s' is filtered out", device_model)
-                device_model = device.get_value("0", "modelInfo") # for BigFoot2020
-            else:
+            gateway_model = device.get_value("gateway", "modelInfo")
+            device_model = device.desc["deviceModel"]
+            _LOGGER.info("Found device '%s' with gateway model '%s'", device_model, gateway_model)
+            # Only process Altherma models for this integration
+            if gateway_model is None:
+                #_LOGGER.warning("Device '%s' is filtered out", model_info)
+                gateway_model = device.get_value("0", "modelInfo") # for BigFoot2020
+            elif device_model == "Altherma":
                 res[dev_data["id"]] = device
+            else:
+                _LOGGER.info("Device '%s' with gateway model '%s' is filtered out because it is not an Altherma model", device_model, gateway_model)
         return res
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/custom_components/daikin_residential_altherma/device.py
+++ b/custom_components/daikin_residential_altherma/device.py
@@ -22,17 +22,17 @@ class DaikinResidentialDevice:
         self.api = apiInstance
 
         self.setJsonData(jsonData)
-        
+
         #DAMIANO
         #self.name = self.get_value("climateControl", "name")
         # per prendere il nome del device coretto
         self.name = self.getName()
-        
-                
+
+
         # self.ip_address = device.device_ip
         # DAMIANO
         self._available = True
-		
+
         _LOGGER.info("Initialized Daikin Residential Device '%s' (id %s)",
             self.name,
             self.getId(),
@@ -120,7 +120,7 @@ class DaikinResidentialDevice:
             # # Damiano deccommentato
             #print('AAAA: [{}] [{}]'.format(mp['embeddedId'], mp))
             #_LOGGER.warning('AAAA: [{}] [{}]'.format(mp['embeddedId'], mp))
-            
+
             dataPoints = {}
             for key in mp.keys():
                 dataPoints[key] = {}
@@ -133,7 +133,7 @@ class DaikinResidentialDevice:
                 ):
                     dataPoints[key] = mp[key]
                 else:
-                    # DAMIANO decommentato 
+                    # DAMIANO decommentato
                     #print('TRAVERSE ' + key + ': ' + json.dumps(dataPoints[key]));
                     dataPoints[key] = self._traverseDatapointStructure(
                         mp[key]["value"], {}
@@ -150,7 +150,7 @@ class DaikinResidentialDevice:
         #print('MPS FOUND: [{}]'.format(self.managementPoints.keys()))
         #_LOGGER.warning('MPS FOUND: [{}]'.format(self.managementPoints))
         #_LOGGER.warning('MPS FOUND: [{}]'.format(self.managementPoints.keys()))
-        
+
 
     def getId(self):
         """Get Daikin Device UUID."""


### PR DESCRIPTION
This PR fixes #5 by filtering out the models that are not "Alterma", I have besides the Altherma 4 FTXM models which are shown as deviceModel dx4. After making this change I do see a lot of Altherma entities which are now in the code. 