### PR TITLE
Changed icon for heat energy to mdi:fire, matches the daikin_resident…

### DIFF
--- a/custom_components/daikin_residential_altherma/const.py
+++ b/custom_components/daikin_residential_altherma/const.py
@@ -135,7 +135,7 @@ SENSOR_TYPES = {
     ATTR_HEAT_ENERGY: {
         CONF_NAME: "Heat Energy Consumption",
         CONF_TYPE: SENSOR_TYPE_ENERGY,
-        CONF_ICON: "mdi:waves-arrow-up",
+        CONF_ICON: "mdi:fire",
         CONF_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
         CONF_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },


### PR DESCRIPTION
…ial integration

    * custom_components/daikin_residential_altherma/const.py: